### PR TITLE
clarify usage; don't silently discard extra args

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ To catch a run-time error/crash entering main:
 
 To catch a build error/crash with custom build flags:
 
-  goreduce -match 'internal compiler error' . 'go build -gcflags "-c=2"'
+  goreduce -match 'internal compiler error' -run 'go build -gcflags "-c=2"' .
 
 Note that you may also call a script or any other program.
 `)
@@ -51,7 +51,7 @@ Note that you may also call a script or any other program.
 func main() {
 	flag.Parse()
 	args := flag.Args()
-	if len(args) < 1 || *matchStr == "" {
+	if len(args) != 1 || *matchStr == "" {
 		flag.Usage()
 		os.Exit(2)
 	}


### PR DESCRIPTION
The usage tripped me up - I thought I could omit `-run` even when altering the command to execute. 
Because the extra args were silently discarded, it took me a while to realize what was happening.